### PR TITLE
Update deps, add readable-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
+  - "8"
+  - "10"
+  - "12"
+  - lts/*
+  - current
 env:
   matrix:
     - TEST_SUITE=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "8"
   - "10"
   - "12"
+  - "14"
   - lts/*
   - current
 env:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 var Buffer = require('safe-buffer').Buffer
-var Transform = require('stream').Transform
+var Transform = require('readable-stream').Transform
 var inherits = require('inherits')
 
 function throwIfNotStringOrBuffer (val, prefix) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "inherits": "^2.0.4",
+    "readable-stream": "^3.6.0",
     "safe-buffer": "^5.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "unit": "node test/*.js"
   },
   "dependencies": {
-    "inherits": "^2.0.1",
-    "safe-buffer": "^5.0.1"
+    "inherits": "^2.0.4",
+    "safe-buffer": "^5.2.0"
   },
   "devDependencies": {
-    "nyc": "^8.3.2",
-    "standard": "*",
-    "tape": "^4.2.0"
+    "nyc": "^15.0.1",
+    "standard": "^14.3.3",
+    "tape": "^5.0.0"
   },
   "engines": {
     "node": ">=4"

--- a/test/index.js
+++ b/test/index.js
@@ -115,9 +115,9 @@ test('HashBase#update', function (t) {
   })
 
   t.test('data length is more than 2^32 bits', function (t) {
-    t.base._length = [ Math.pow(2, 32) - 1, 0, 0, 0 ]
+    t.base._length = [Math.pow(2, 32) - 1, 0, 0, 0]
     t.base.update(Buffer.allocUnsafe(1))
-    t.same(t.base._length, [ 7, 1, 0, 0 ])
+    t.same(t.base._length, [7, 1, 0, 0])
     t.end()
   })
 


### PR DESCRIPTION
the main thing here is switching out `stream` for `readable-stream`. With Webpack not updating their node-libs-browser we're not getting a newer version of stream-browserify so things break because of breaking changes in readable-stream. So this just bypasses that problem entirely and goes straight to readable-stream which it's using anyway. Also pinning to readable-stream gives some nice stability guarantees.

I'm using this through ripemd160 for btc stuff btw, 👍 on that.